### PR TITLE
Remove newlines from morgan-body logging

### DIFF
--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -93,7 +93,7 @@ morganBody(graphQLServer, {
   logResponseBody: config.get('requestLogger') === 'true',
   stream: {
     write: (message) => {
-      logger.info(message);
+      logger.info(message.trimEnd());
     },
   },
 });


### PR DESCRIPTION
See https://stackoverflow.com/questions/40602106/how-to-remove-empty-lines-that-are-being-generated-in-a-log-file-from-morgan-log

I noticed that our logging has lots of newlines. I'm assuming this is a result of the logging change. Not sure if this is something we want or not:
```
[2020-10-01T10:28:14.019] [INFO] [grc-ui-api] [server] Response: 200 1708.044 ms

[2020-10-01T10:28:17.672] [INFO] [grc-ui-api] [server] Request: POST /grcuiapi/graphql at Thu Oct 01 2020 10:28:17 GMT-0400, IP: ::ffff:127.0.0.1, User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0

[2020-10-01T10:28:17.672] [INFO] [grc-ui-api] [server] Response: 200 3518.351 ms

[2020-10-01T10:28:53.113] [INFO] [grc-ui-api] [server] Request: POST /grcuiapi/graphql at Thu Oct 01 2020 10:28:53 GMT-0400, IP: ::ffff:127.0.0.1, User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0

```
**vs**
```
[2020-10-01T10:54:38.879] [INFO] [grc-ui-api] [server] Response: 200 3237.011 ms
[2020-10-01T10:54:52.656] [INFO] [grc-ui-api] [server] Request: POST /grcuiapi/graphql at Thu Oct 01 2020 10:54:52 GMT-0400, IP: ::ffff:127.0.0.1, User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:78.0) Gecko/20100101 Firefox/78.0
[2020-10-01T10:54:52.656] [INFO] [grc-ui-api] [server] Response: 200 2065.398 ms
[2020-10-01T10:54:58.615] [INFO] [grc-ui-api] [server] Request: POST /grcuiapi/graphql at Thu Oct 01 2020 10:54:58 GMT-0400,
```