### PR TITLE
[release-2.2] Push a `latest-2.2` tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,11 @@ jobs:
         - make component/push
         - echo '"finished image push"' && echo -en 'travis_fold:end:script.build\\r'
         - if [ "$IMAGE_SCAN" != "false" ]; then make security/scans; fi;
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then 
-            export COMPONENT_NEWTAG="latest-dev";
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "release-2.2" ]; then 
+            export COMPONENT_NEWTAG="latest-2.2";
             make component/tag;
             export COMPONENT_VERSION="latest";
-            export COMPONENT_TAG_EXTENSION="-dev";
+            export COMPONENT_TAG_EXTENSION="-2.2";
             make component/push;
           fi;
     - stage: unit-test


### PR DESCRIPTION
This tag is used by our GRC E2E tests to easily identify the latest versioned image.
