### PR TITLE
Rebuild Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ The UI API microservice, `grc-ui-api`, is the API server for the governance and 
 <!---
 Date: 08/17/2021
 -->
+


### PR DESCRIPTION
`grc-ui-api` no longer used in 2.5 and removed from pipeline in https://github.com/stolostron/pipeline/commit/f2c21a56ea075b72f080789f7e5fbc22b279db0d

No-op pr to resolve https://github.com/stolostron/backlog/issues/20741

Signed-off-by: Patrick Hickey <pahickey@redhat.com>